### PR TITLE
Remove Deezy type exception

### DIFF
--- a/geoparser/ranking.py
+++ b/geoparser/ranking.py
@@ -275,48 +275,43 @@ class Ranker:
         remainers = [x for x, y in cands_dict.items() if len(y) == 0]
 
         if remainers:
-            try:
-                candidates = candidate_ranker(
-                    candidate_scenario=os.path.join(
-                        dm_path, "combined", dm_cands + "_" + dm_model
-                    ),
-                    query=remainers,
-                    ranking_metric=self.deezy_parameters["ranking_metric"],
-                    selection_threshold=self.deezy_parameters["selection_threshold"],
-                    num_candidates=self.deezy_parameters["num_candidates"],
-                    search_size=self.deezy_parameters["search_size"],
-                    verbose=self.deezy_parameters["verbose"],
-                    output_path=os.path.join(dm_path, "ranking", dm_output),
-                    pretrained_model_path=os.path.join(
-                        f"{dm_path}", "models", f"{dm_model}", f"{dm_model}" + ".model"
-                    ),
-                    pretrained_vocab_path=os.path.join(
-                        f"{dm_path}", "models", f"{dm_model}", f"{dm_model}" + ".vocab"
-                    ),
-                )
+            candidates = candidate_ranker(
+                candidate_scenario=os.path.join(
+                    dm_path, "combined", dm_cands + "_" + dm_model
+                ),
+                query=remainers,
+                ranking_metric=self.deezy_parameters["ranking_metric"],
+                selection_threshold=self.deezy_parameters["selection_threshold"],
+                num_candidates=self.deezy_parameters["num_candidates"],
+                search_size=self.deezy_parameters["search_size"],
+                verbose=self.deezy_parameters["verbose"],
+                output_path=os.path.join(dm_path, "ranking", dm_output),
+                pretrained_model_path=os.path.join(
+                    f"{dm_path}", "models", f"{dm_model}", f"{dm_model}" + ".model"
+                ),
+                pretrained_vocab_path=os.path.join(
+                    f"{dm_path}", "models", f"{dm_model}", f"{dm_model}" + ".vocab"
+                ),
+            )
 
-                for idx, row in candidates.iterrows():
-                    # Reverse cosine distance to cosine similarity:
-                    returned_cands = dict()
-                    if self.deezy_parameters["ranking_metric"] == "faiss":
-                        returned_cands = row["faiss_distance"]
-                        returned_cands = {
-                            k: (
-                                self.deezy_parameters["selection_threshold"]
-                                - returned_cands[k]
-                            )
-                            / self.deezy_parameters["selection_threshold"]
-                            for k in returned_cands
-                        }
-                    else:
-                        returned_cands = row["cosine_dist"]
-                        returned_cands = {
-                            k: 1 - returned_cands[k] for k in returned_cands
-                        }
-                    cands_dict[row["query"]] = returned_cands
-                    self.already_collected_cands[row["query"]] = returned_cands
-            except TypeError:
-                pass
+            for idx, row in candidates.iterrows():
+                # Reverse cosine distance to cosine similarity:
+                returned_cands = dict()
+                if self.deezy_parameters["ranking_metric"] == "faiss":
+                    returned_cands = row["faiss_distance"]
+                    returned_cands = {
+                        k: (
+                            self.deezy_parameters["selection_threshold"]
+                            - returned_cands[k]
+                        )
+                        / self.deezy_parameters["selection_threshold"]
+                        for k in returned_cands
+                    }
+                else:
+                    returned_cands = row["cosine_dist"]
+                    returned_cands = {k: 1 - returned_cands[k] for k in returned_cands}
+                cands_dict[row["query"]] = returned_cands
+                self.already_collected_cands[row["query"]] = returned_cands
 
         return cands_dict, self.already_collected_cands
 


### PR DESCRIPTION
It seems [this issue](https://github.com/Living-with-machines/toponym-resolution/issues/106), addressing [this comment](https://github.com/Living-with-machines/toponym-resolution/pull/101#discussion_r840619385), has been fixed (I believe it was due to a DeezyMatch bug which has already been fixed): I have run the pipeline with DeezyMatch and haven't got the error, so I think we can remove the exception. Could you have a look, @fedenanni, when you have a moment?